### PR TITLE
Output before headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# CodeIgniter header-sent hotfix
+
+This repository captures a small hotfix for the fatal error:
+
+```
+Cannot modify header information - headers already sent by ...
+```
+
+In older CodeIgniter 4.x releases the exception handler always calls
+`header(...)` even when output has already started. That produces a second
+ErrorException and masks the original error.
+
+## Fix (hotfix patch)
+
+Apply the patch below to the framework file in your project:
+
+```
+git apply patches/codeigniter4-exceptions-headers-sent.patch
+```
+
+The patch adds a `headers_sent()` guard around the header call.
+
+## Also fix the root output source
+
+The first "headers already sent" message always points at the real file
+that started output (for example a stray BOM or debug `echo`). Remove that
+output so headers can be set normally.
+
+## Preferred long-term fix
+
+Upgrade to a newer CodeIgniter release where the guard already exists.

--- a/patches/codeigniter4-exceptions-headers-sent.patch
+++ b/patches/codeigniter4-exceptions-headers-sent.patch
@@ -1,0 +1,11 @@
+diff --git a/vendor/codeigniter4/framework/system/Debug/Exceptions.php b/vendor/codeigniter4/framework/system/Debug/Exceptions.php
+index 1b0c0b1..c2c2a55 100644
+--- a/vendor/codeigniter4/framework/system/Debug/Exceptions.php
++++ b/vendor/codeigniter4/framework/system/Debug/Exceptions.php
+@@
+-			$header = "HTTP/{$this->request->getProtocolVersion()} {$this->response->getStatusCode()} {$this->response->getReason()}";
+-			header($header, true, $statusCode);
++			$header = "HTTP/{$this->request->getProtocolVersion()} {$this->response->getStatusCode()} {$this->response->getReason()}";
++			if (! headers_sent()) {
++				header($header, true, $statusCode);
++			}


### PR DESCRIPTION
Add a hotfix patch and documentation to prevent "Cannot modify header information" errors in older CodeIgniter 4.x installations.

The error occurs when CodeIgniter's exception handler attempts to set HTTP status headers after output has already started, leading to a secondary `ErrorException` that masks the original problem. The patch adds a `headers_sent()` check to prevent this secondary error, and the README provides guidance on applying the patch and addressing the underlying cause of early output.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-b958ad2b-b163-4680-9776-896e71c70cda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b958ad2b-b163-4680-9776-896e71c70cda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

